### PR TITLE
add DEBUG=* logging support

### DIFF
--- a/lib/bionode-ncbi.js
+++ b/lib/bionode-ncbi.js
@@ -31,6 +31,7 @@ var JSONStream = require('JSONStream')
 var xml2js = require('xml2js').parseString
 var dld = require('dld')
 var tool = require('tool-stream')
+var debug = require('debug')('bionode-ncbi')
 
 
 module.exports = exports = ncbi = new NCBI()
@@ -93,11 +94,22 @@ NCBI.prototype.search = function(db, term) {
       'term=' + encodeURI(obj),
       'usehistory=y'
     ].join('&')
+    
     var getUIDs = _requestData(db)
-    request({ uri: query, json: true })
+    
+    debug('esearch request', query)
+    
+    var req = request({ uri: query, json: true })
+    
+    req.on('response', function(resp) {
+      debug('esearch response', resp.statusCode)
+    })
+    
+    req
     .pipe(JSONStream.parse())
     .pipe(_requestsSplit(db))
     .pipe(getUIDs)
+    
     _attachStandardEvents(getUIDs, self, next)
   }
 }
@@ -105,6 +117,7 @@ NCBI.prototype.search = function(db, term) {
 function _requestsSplit(db) {
   return through.obj(transform)
   function transform(obj, enc, next) {
+    debug('esearch results', obj)
     var self = this
     var webenv = obj.esearchresult.webenv
     var count = obj.esearchresult.count
@@ -144,8 +157,16 @@ function _requestData(db) {
     else {
       _attachStandardEvents(finish, self, next)
     }
-
-    request({uri: query, json: true})
+    
+    debug('esummary request', query)
+    
+    var req = request({uri: query, json: true})
+    
+    req.on('response', function(resp) {
+      debug('esummary response', resp.statusCode)
+    })
+    
+    req
     .pipe(JSONStream.parse())
     .pipe(tool.extractProperty('result'))
     .pipe(tool.deleteProperty('uids'))
@@ -197,7 +218,9 @@ NCBI.prototype.link = function(srcDB, destDB, srcUID) {
     var linkName = srcDB+'_'+destDB
 
     var getLink = tool.attachToObject(link, 'destUID')
-
+    
+    debug('elink request', query)
+    
     request({ uri: query, json: true })
     .pipe(_wait(500))
     .pipe(tool.XMLToJS(true))
@@ -315,6 +338,7 @@ function _download(db, term) {
 
     mkdirp.sync(obj.uid)
     if (!fs.existsSync(path)) {
+      debug('downloading', obj.url)
       dld(obj.url, folder, chunkSize)
       .on('data', log)
       .on('end', function() {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "xml2js": "^0.4.3"
   },
   "devDependencies": {
+    "coveralls": "~2.6.1",
+    "debug": "^1.0.2",
+    "docco": "~0.6.2",
+    "istanbul": "~0.2.4",
     "mocha": "~1.17.0",
     "mocha-lcov-reporter": "0.0.1",
-    "should": "~3.0.1",
-    "istanbul": "~0.2.4",
-    "coveralls": "~2.6.1",
-    "docco": "~0.6.2"
+    "should": "~3.0.1"
   },
   "keywords": [
     "ncbi",


### PR DESCRIPTION
added some debug statements so you can do `DEBUG=*` before the command for it to print out what requests/responses it gets
