### PR TITLE
download from protein database

### DIFF
--- a/lib/bionode-ncbi.js
+++ b/lib/bionode-ncbi.js
@@ -429,7 +429,7 @@ function createFTPURL(db) {
     function proteinURL(){
       'http://www.ncbi.nlm.nih.gov/protein/XP_009457936.1?report=fasta&log$=seqview&format=text'
       var runs = obj.runs.Run
-      async.eachSeries(runs, printSRAURL, next)
+      async.eachSeries(runs, printProteinURL, next)
       function printProteinURL(run, cb) {
         var acc = run.acc
         var runURL = [

--- a/lib/bionode-ncbi.js
+++ b/lib/bionode-ncbi.js
@@ -403,7 +403,8 @@ function createFTPURL(db) {
     var self = this
     var parseURL = {
       sra: sraURL,
-      assembly: assemblyURL
+      assembly: assemblyURL,
+      protein: proteinURL
     }
 
     parseURL[db]()
@@ -425,6 +426,22 @@ function createFTPURL(db) {
       }
     }
 
+    function proteinURL(){
+      'http://www.ncbi.nlm.nih.gov/protein/XP_009457936.1?report=fasta&log$=seqview&format=text'
+      var runs = obj.runs.Run
+      async.eachSeries(runs, printSRAURL, next)
+      function printProteinURL(run, cb) {
+        var acc = run.acc
+        var runURL = [
+          'http://www.ncbi.nlm.nih.gov/protein/',
+          obj.accessionversion,
+          '?report=fasta&log$=seqview&format=text'
+        ].join('')
+        self.push({url: runURL, uid: obj.uid})
+        cb()
+      }
+    }
+    
     function assemblyURL() {
       if (obj.meta.FtpSites) {
         var ftpPath = obj.meta.FtpSites.FtpPath


### PR DESCRIPTION
Hello,
I am attempting to add the protein database, in addition to SRA and Assembly to download fasta files (or a big fasta file). I was going off of `assemblyURL`, and I tried putting in the URL I got from searching for a protein fasta, which looked like this: `http://www.ncbi.nlm.nih.gov/protein/XP_009457936.1?report=fasta&log$=seqview&format=text` (this isn't a pure fasta file, it still has html formatting, so not sure what to do about that)

I'd like to download all protein sequence files for the gene "POLR2L", which I'm doing with:

```
bionode-ncbi download protein polr2l
```

This is the error I'm currently getting with this code:

```
TypeError: Cannot read property 'Run' of undefined
    at Object.proteinURL [as protein] (/usr/local/lib/node_modules/bionode-ncbi/lib/bionode-ncbi.js:431:26)
    at DestroyableTransform.transform [as _transform] (/usr/local/lib/node_modules/bionode-ncbi/lib/bionode-ncbi.js:410:17)
    at DestroyableTransform.Transform._read (/usr/local/lib/node_modules/bionode-ncbi/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/usr/local/lib/node_modules/bionode-ncbi/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/local/lib/node_modules/bionode-ncbi/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/local/lib/node_modules/bionode-ncbi/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/usr/local/lib/node_modules/bionode-ncbi/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/usr/local/lib/node_modules/bionode-ncbi/node_modules/pumpify/node_modules/duplexify/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/usr/local/lib/node_modules/bionode-ncbi/node_modules/pumpify/node_modules/duplexify/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at pipeOnReadable (/usr/local/lib/node_modules/bionode-ncbi/node_modules/pumpify/node_modules/duplexify/node_modules/readable-stream/lib/_stream_readable.js:664:5)
```

I think this bug originates from my misunderstanding of what `runURL` does in the `<database>URL` functions. Can you clarify?

Thanks!
Olga