### PR TITLE
Prevent progress bar from starting if file already exists

### DIFF
--- a/docs/bionode-ncbi.html
+++ b/docs/bionode-ncbi.html
@@ -26,7 +26,7 @@
 <p>Node.js module for working with the NCBI API (aka e-utils) using Streams.</p>
 <p>doi: <a href="http://dx.doi.org/10.5281/zenodo.10610">10.5281/zenodo.10610</a>
 author: <a href="http://bmpvieira.com">Bruno Vieira</a>
-email: <a href="&#109;&#97;&#x69;&#x6c;&#116;&#111;&#58;&#x6d;&#97;&#x69;&#108;&#x40;&#x62;&#109;&#x70;&#118;&#105;&#101;&#105;&#x72;&#97;&#46;&#99;&#111;&#109;">&#x6d;&#97;&#x69;&#108;&#x40;&#x62;&#109;&#x70;&#118;&#105;&#101;&#105;&#x72;&#97;&#46;&#99;&#111;&#109;</a>
+email: <a href="&#109;&#97;&#105;&#x6c;&#x74;&#111;&#x3a;&#109;&#97;&#x69;&#x6c;&#64;&#98;&#x6d;&#x70;&#118;&#x69;&#101;&#105;&#114;&#x61;&#46;&#x63;&#111;&#x6d;">&#109;&#97;&#x69;&#x6c;&#64;&#98;&#x6d;&#x70;&#118;&#x69;&#101;&#105;&#114;&#x61;&#46;&#x63;&#111;&#x6d;</a>
 license: <a href="https://raw.githubusercontent.com/bionode/bionode-ncbi/master/LICENSE">MIT</a></p>
 </blockquote>
 <hr>
@@ -451,22 +451,9 @@ ncbi.download = <span class="hljs-function"><span class="hljs-keyword">function<
       <span class="hljs-string">'faa'</span>: <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params"></span>) </span>{ <span class="hljs-keyword">return</span> obj.protein.faa },
       <span class="hljs-string">'repeats'</span>: <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params"></span>) </span>{ <span class="hljs-keyword">return</span> obj.rm.out },
       <span class="hljs-string">'md5'</span>: <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params"></span>) </span>{ <span class="hljs-keyword">return</span> obj.md5checksums.txt }
-    }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-7">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-7">&#182;</a>
-              </div>
-              <p>added opts.db definition here since it is a local variable in ncbi.urls</p>
+    }
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">var</span> opts = <span class="hljs-keyword">typeof</span> db === <span class="hljs-string">'string'</span> ? { <span class="hljs-attr">db</span>: db } : db
+    <span class="hljs-keyword">var</span> opts = <span class="hljs-keyword">typeof</span> db === <span class="hljs-string">'string'</span> ? { <span class="hljs-attr">db</span>: db } : db
 
     <span class="hljs-keyword">var</span> url = extractFiles[opts.db]()
 
@@ -484,10 +471,16 @@ ncbi.download = <span class="hljs-function"><span class="hljs-keyword">function<
       debug(<span class="hljs-string">'downloading'</span>, url)
       <span class="hljs-keyword">var</span> options
       <span class="hljs-keyword">if</span> (opts.pretty === <span class="hljs-literal">true</span>) {
-        options = { <span class="hljs-attr">dir</span>: folder, <span class="hljs-attr">resume</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">quiet</span>: <span class="hljs-literal">false</span> }
+        <span class="hljs-keyword">if</span> (fs.existsSync(path)) {
+          <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'File already exists in: '</span> + path + <span class="hljs-string">'\n'</span>)
+          options = { <span class="hljs-attr">dir</span>: folder, <span class="hljs-attr">resume</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">quiet</span>: <span class="hljs-literal">true</span> }
+        } <span class="hljs-keyword">else</span> {
+          options = { <span class="hljs-attr">dir</span>: folder, <span class="hljs-attr">resume</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">quiet</span>: <span class="hljs-literal">false</span> }
+        }
       } <span class="hljs-keyword">else</span> {
         options = { <span class="hljs-attr">dir</span>: folder, <span class="hljs-attr">resume</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">quiet</span>: <span class="hljs-literal">true</span> }
       }
+
       <span class="hljs-keyword">var</span> dld = nugget(PROXY + url, options, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">err</span>) </span>{
         <span class="hljs-keyword">if</span> (err) <span class="hljs-keyword">return</span> self.destroy(err)
         fs.stat(path, gotStat)
@@ -497,7 +490,6 @@ ncbi.download = <span class="hljs-function"><span class="hljs-keyword">function<
           log.speed = <span class="hljs-string">'NA'</span>
           log.size = <span class="hljs-built_in">Math</span>.round(stat.size / <span class="hljs-number">1024</span> / <span class="hljs-number">1024</span>) + <span class="hljs-string">' MB'</span>
           self.push(log)
-          <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'\nFile saved at '</span> + path)
           next()
         }
       })
@@ -519,11 +511,11 @@ ncbi.download = <span class="hljs-function"><span class="hljs-keyword">function<
         </li>
         
         
-        <li id="section-8">
+        <li id="section-7">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-8">&#182;</a>
+                <a class="pilcrow" href="#section-7">&#182;</a>
               </div>
               <h2 id="urls">URLs</h2>
 <p>Takes a NCBI database string and a optional search term and returns as stream of dataset/sequence files URLs.
@@ -591,11 +583,11 @@ ncbi.urls = <span class="hljs-function"><span class="hljs-keyword">function</spa
         </li>
         
         
-        <li id="section-9">
+        <li id="section-8">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-9">&#182;</a>
+                <a class="pilcrow" href="#section-8">&#182;</a>
               </div>
               <p>NCBI seems to return GenBank and RefSeq accessions for the same thing. We only need one.</p>
 
@@ -671,11 +663,11 @@ ncbi.urls = <span class="hljs-function"><span class="hljs-keyword">function</spa
         </li>
         
         
-        <li id="section-10">
+        <li id="section-9">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-10">&#182;</a>
+                <a class="pilcrow" href="#section-9">&#182;</a>
               </div>
               <h2 id="expand">Expand</h2>
 <p>Takes a property (e.g., biosample) and optional destination property
@@ -707,11 +699,11 @@ ncbi.expand = <span class="hljs-function"><span class="hljs-keyword">function</s
         </li>
         
         
-        <li id="section-11">
+        <li id="section-10">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-11">&#182;</a>
+                <a class="pilcrow" href="#section-10">&#182;</a>
               </div>
               <p>Taxonomy doesn’t work just with ID number</p>
 
@@ -744,11 +736,11 @@ ncbi.expand = <span class="hljs-function"><span class="hljs-keyword">function</s
         </li>
         
         
-        <li id="section-12">
+        <li id="section-11">
             <div class="annotation">
               
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-12">&#182;</a>
+                <a class="pilcrow" href="#section-11">&#182;</a>
               </div>
               <h2 id="fetch">Fetch</h2>
 <p>Allows retrieval of records from NCBI databases. Takes the database name and a search term,

--- a/lib/bionode-ncbi.js
+++ b/lib/bionode-ncbi.js
@@ -400,10 +400,16 @@ function download (db) {
       debug('downloading', url)
       var options
       if (opts.pretty === true) {
-        options = { dir: folder, resume: true, quiet: false }
+        if (fs.existsSync(path)) {
+          console.log('File already exists in: ' + path + '\n')
+          options = { dir: folder, resume: true, quiet: true }
+        } else {
+          options = { dir: folder, resume: true, quiet: false }
+        }
       } else {
         options = { dir: folder, resume: true, quiet: true }
       }
+
       var dld = nugget(PROXY + url, options, function (err) {
         if (err) return self.destroy(err)
         fs.stat(path, gotStat)


### PR DESCRIPTION
This change only affects --pretty option, and prevents progress bar from starting when file already exists, which rendered an odd 0% progress when output already exists in file system. Makes more sense if we raise an error message and do not start progress bar at all.