### PR TITLE
Do the db filter at lib level

### DIFF
--- a/lib/bionode-ncbi.js
+++ b/lib/bionode-ncbi.js
@@ -40,6 +40,9 @@ var cheerio = require('cheerio')
 var fasta = require('bionode-fasta')
 var insight = require('./anonymous-tracking')
 
+var validDbs = require('./valid-dbs')
+var InvalidDbError = validDbs.InvalidDbError
+
 var ncbi = exports
 
 var PROXY = typeof window !== 'undefined' ? 'http://cors.inb.io/' : ''
@@ -110,6 +113,10 @@ ncbi.search = function (db, term, cb) {
   insight.track('ncbi', 'search')
   var opts = typeof db === 'string' ? { db, term } : db
   cb = typeof term === 'function' ? term : cb
+
+  if (Object.keys(validDbs.dbs).indexOf(opts.db) < 0) {
+    throw new InvalidDbError('The database "' + opts.db + '" is not a valid ncbi database')
+  }
 
   var stream = pumpify.obj(
     createAPISearchUrl(opts.db, opts.term),

--- a/lib/valid-dbs.js
+++ b/lib/valid-dbs.js
@@ -1,0 +1,72 @@
+
+var dbs = {
+  gquery: 'All Databases',
+  assembly: 'Assembly',
+  bioproject: 'BioProject',
+  biosample: 'BioSample',
+  biosystems: 'BioSystems',
+  books: 'Books',
+  clinvar: 'ClinVar',
+  clone: 'Clone',
+  cdd: 'Conserved Domains',
+  gap: 'dbGaP',
+  dbvar: 'dbVar',
+  nucest: 'EST',
+  gene: 'Gene',
+  genome: 'Genome',
+  gds: 'GEO DataSets',
+  geoprofiles: 'GEO Profiles',
+  nucgss: 'GSS',
+  gtr: 'GTR',
+  homologene: 'HomoloGene',
+  medgen: 'MedGen',
+  mesh: 'MeSH',
+  ncbisearch: 'NCBI Web Site',
+  nlmcatalog: 'NLM Catalog',
+  nuccore: 'Nucleotide',
+  omim: 'OMIM',
+  pmc: 'PMC',
+  popset: 'PopSet',
+  probe: 'Probe',
+  protein: 'Protein',
+  proteinclusters: 'Protein Clusters',
+  pcassay: 'PubChem BioAssay',
+  pccompound: 'PubChem Compound',
+  pcsubstance: 'PubChem Substance',
+  pubmed: 'PubMed',
+  pubmedhealth: 'PubMed Health',
+  snp: 'SNP',
+  sparcle: 'Sparcle',
+  sra: 'SRA',
+  structure: 'Structure',
+  taxonomy: 'Taxonomy',
+  toolkit: 'ToolKit',
+  toolkitall: 'ToolKitAll',
+  toolkitbook: 'ToolKitBook',
+  toolkitbookgh: 'ToolKitBookgh',
+  unigene: 'UniGene'
+}
+
+function printDbs (dbsObject) {
+  dbsObject = dbsObject || dbs
+
+  var keys = Object.keys(dbsObject)
+  return keys.reduce((acc, k, i) => {
+    acc = acc + k + ' (' + dbsObject[k] + ')'
+    if (i < keys.length - 1) {
+      acc = acc + '\n'
+    }
+    return acc
+  }, '')
+}
+
+function InvalidDbError (msg) {
+  this.name = 'InvalidDbError'
+  this.message = msg
+}
+
+InvalidDbError.prototype = new Error('Invalid database')
+
+module.exports.dbs = dbs
+module.exports.InvalidDbError = InvalidDbError
+module.exports.printDbs = printDbs

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "bionode-ncbi": "cli.js"
   },
   "scripts": {
-    "test": "standard && dependency-check . && node test/*.js | tap-spec",
+    "test": "standard && dependency-check . && tape test/**/*.js | tap-spec",
     "test-browser": "browserify test/*.js -d | testling -x 'open -a \"Google Chrome\"' | tap-spec",
-    "coverage": "standard && dependency-check . && istanbul cover test/bionode-ncbi.js --report lcovonly -- | tap-spec && rm -rf ./coverage",
-    "coveralls": "istanbul cover test/bionode-ncbi.js --report lcovonly -- | tap-spec && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls && rm -rf ./coverage",
+    "coverage": "standard && dependency-check . && istanbul cover tape test/**/*.js --report lcovonly -- | tap-spec && rm -rf ./coverage",
+    "coveralls": "istanbul cover tape test/**/*.js --report lcovonly -- | tap-spec && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls && rm -rf ./coverage",
     "build-browser": "browserify -r ./index.js:bionode-ncbi | uglifyjs > bionode-ncbi.min.js",
     "build-docs": "docco ./lib/bionode-ncbi.js"
   },

--- a/test/valid-dbs.js
+++ b/test/valid-dbs.js
@@ -1,0 +1,27 @@
+var tape = require('tape')
+var tapeNock = require('tape-nock')
+var validDbs = require('../lib/valid-dbs')
+var ncbi = require('../lib/bionode-ncbi')
+
+var test = tapeNock(tape)
+
+test('valid-dbs printDbs', t => {
+  var dummy = {fakedb: 'Fake!', another: 'Another'}
+
+  var expected = 'fakedb (Fake!)\nanother (Another)'
+
+  t.equals(validDbs.printDbs(dummy), expected, 'printDbs returns the expected string')
+
+  t.end()
+})
+
+// TODO move this test to a suite just for bionode-ncbi search
+test('bionode-ncbi search', t => {
+  t.plan(1)
+
+  try {
+    ncbi.search('invalid', 'human')
+  } catch (err) {
+    t.assert(err instanceof validDbs.InvalidDbError, 'call search with wrong db throws InvalidDbError')
+  }
+})


### PR DESCRIPTION
This PR references #20

A new module `valid-dbs` is defined in `/lib/valid-dbs.js` to handle the logic of the valid dbs.
It exports:
 - `dbs` An object that contains the valid db options as keys and descriptions.
 - `InvalidDbError` Custom Error to throw in functions that require a valid dbs
 - `printDbs` A function that pretty prints the dbs following this format `key (description)` and separated by new lines.

This also modifies the search function in main ncbi lib file to throw an exception is the db is invalid.
Minor modifications to the cli file to use the `valid-dbs` module to handle the logic when no valid db is provided.
Updates the package.json file so all the test files are run in the CI and the coverage reporter uses all the test results.