### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/docs/bionode-ncbi.html
+++ b/docs/bionode-ncbi.html
@@ -24,7 +24,7 @@
               <h1 id="bionode-ncbi">bionode-ncbi</h1>
 <blockquote>
 <p>Node.js module for working with the NCBI API (aka e-utils) using Streams.</p>
-<p>doi: <a href="http://dx.doi.org/10.5281/zenodo.10610">10.5281/zenodo.10610</a>
+<p>doi: <a href="https://doi.org/10.5281/zenodo.10610">10.5281/zenodo.10610</a>
 author: <a href="http://bmpvieira.com">Bruno Vieira</a>
 email: <a href="&#109;&#97;&#105;&#x6c;&#x74;&#111;&#x3a;&#109;&#97;&#x69;&#x6c;&#64;&#98;&#x6d;&#x70;&#118;&#x69;&#101;&#105;&#114;&#x61;&#46;&#x63;&#111;&#x6d;">&#109;&#97;&#x69;&#x6c;&#64;&#98;&#x6d;&#x70;&#118;&#x69;&#101;&#105;&#114;&#x61;&#46;&#x63;&#111;&#x6d;</a>
 license: <a href="https://raw.githubusercontent.com/bionode/bionode-ncbi/master/LICENSE">MIT</a></p>

--- a/lib/bionode-ncbi.js
+++ b/lib/bionode-ncbi.js
@@ -1,7 +1,7 @@
 // # bionode-ncbi
 // > Node.js module for working with the NCBI API (aka e-utils) using Streams.
 // >
-// > doi: [10.5281/zenodo.10610](http://dx.doi.org/10.5281/zenodo.10610)
+// > doi: [10.5281/zenodo.10610](https://doi.org/10.5281/zenodo.10610)
 // > author: [Bruno Vieira](http://bmpvieira.com)
 // > email: <mail@bmpvieira.com>
 // > license: [MIT](https://raw.githubusercontent.com/bionode/bionode-ncbi/master/LICENSE)


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!